### PR TITLE
feat: add founder notification for new registrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,5 +14,9 @@ INTERNAL_DIRECTORY_SECRET=
 
 # Resend (booking emails). Domain mydoccy.com must be verified in Resend.
 RESEND_API_KEY=
+# Founder alert when a professional completes signup (comma-separated emails OK)
+# FOUNDER_NOTIFY_EMAIL=you@example.com
+# Optional: WhatsApp via GET webhook (?text=...) — can mirror WHATSAPP_WEBHOOK_URL style from CI
+# FOUNDER_REGISTRATION_WHATSAPP_WEBHOOK_URL=
 # Optional: override From (default: DocCy <no-reply@mydoccy.com>). Use for dev e.g. Resend onboarding sender.
 # RESEND_FROM=DocCy <onboarding@resend.dev>

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -11,6 +11,7 @@ import {
   parseSpecialtyFromMasterField,
   validateSpecialtySubmission,
 } from "@/lib/specialty-submission";
+import { notifyFounderNewRegistration } from "@/lib/notify-founder-new-registration";
 
 type PageProps = {
   searchParams?: { submitted?: string; error?: string; debug?: string };
@@ -337,6 +338,19 @@ async function handleRegister(formData: FormData) {
     doctorId = fallbackInsert.data.id as string;
   }
 
+  const queueFounderSignupNotify = () => {
+    void notifyFounderNewRegistration({
+      doctorId,
+      fullName,
+      email,
+      phone,
+      specialty,
+      needsSpecialtyReview: !isSpecialtyApproved,
+    }).catch((err) =>
+      console.error("[DocCy] Founder registration notify failed", err)
+    );
+  };
+
   const { error: avatarSaveError } = await service
     .from("doctors")
     .update({ avatar_url: avatarFileUrl })
@@ -351,6 +365,7 @@ async function handleRegister(formData: FormData) {
       console.warn(
         "[DocCy] avatar_url column missing on doctors. Apply SQL migration to persist avatar path."
       );
+      queueFounderSignupNotify();
       redirect("/register?submitted=1");
     }
     console.error("[DocCy] Failed to save avatar_url on doctor", avatarSaveError);
@@ -365,6 +380,7 @@ async function handleRegister(formData: FormData) {
     redirectWithError("avatar_save", avatarSaveError);
   }
 
+  queueFounderSignupNotify();
   redirect("/register?submitted=1");
 }
 

--- a/lib/notify-founder-new-registration.ts
+++ b/lib/notify-founder-new-registration.ts
@@ -1,0 +1,102 @@
+import { sendResendEmail } from "@/lib/resend";
+import { getPublicBookingBaseUrl } from "@/lib/site-url";
+
+export type NewRegistrationNotifyPayload = {
+  doctorId: string;
+  fullName: string;
+  email: string;
+  phone: string;
+  specialty: string;
+  /** Custom "Other" specialty pending founder approval */
+  needsSpecialtyReview: boolean;
+};
+
+/**
+ * Strips legacy `text=` from webhook query (same idea as prod monitoring curl).
+ */
+function buildWhatsAppWebhookUrlWithText(webhookUrl: string, text: string): string {
+  const trimmed = webhookUrl.trim().replace(/\r|\n/g, "");
+  const withoutText = trimmed
+    .replace(/([?&])text=[^&]*(&|$)/g, (_m, p1: string, p2: string) =>
+      p2 === "&" ? p1 : ""
+    )
+    .replace(/\?&/g, "?")
+    .replace(/&&/g, "&")
+    .replace(/[?&]$/, "");
+  const u = new URL(withoutText);
+  u.searchParams.set("text", text);
+  return u.toString();
+}
+
+async function sendFounderWhatsApp(webhookUrl: string, text: string): Promise<void> {
+  const url = buildWhatsAppWebhookUrlWithText(webhookUrl, text);
+  const res = await fetch(url, { method: "GET", signal: AbortSignal.timeout(20_000) });
+  if (!res.ok) {
+    throw new Error(`WhatsApp webhook HTTP ${res.status}`);
+  }
+}
+
+/**
+ * Best-effort alerts when a professional completes signup (pending your verification).
+ *
+ * Configure either or both:
+ * - FOUNDER_NOTIFY_EMAIL — Resend recipient(s), comma-separated allowed
+ * - FOUNDER_REGISTRATION_WHATSAPP_WEBHOOK_URL — GET webhook with `text` param (e.g. same style as WHATSAPP_WEBHOOK_URL in CI)
+ */
+export async function notifyFounderNewRegistration(
+  payload: NewRegistrationNotifyPayload
+): Promise<void> {
+  const emailTo = process.env.FOUNDER_NOTIFY_EMAIL?.trim();
+  const waWebhook = process.env.FOUNDER_REGISTRATION_WHATSAPP_WEBHOOK_URL?.trim();
+
+  if (!emailTo && !waWebhook) {
+    return;
+  }
+
+  const base = getPublicBookingBaseUrl();
+  const reviewPath = "/internal/directory";
+  const reviewUrl = `${base}${reviewPath}`;
+
+  const lines = [
+    `New professional registration (pending verification)`,
+    `Name: ${payload.fullName}`,
+    `Email: ${payload.email}`,
+    `Phone: ${payload.phone}`,
+    `Specialty: ${payload.specialty}`,
+    payload.needsSpecialtyReview ? `Note: custom specialty pending your approval` : null,
+    `Doctor id: ${payload.doctorId}`,
+    `Review: ${reviewUrl}`,
+  ].filter(Boolean) as string[];
+
+  const textBody = lines.join("\n");
+  const shortWa = `DocCy: new signup — ${payload.fullName} (${payload.specialty}). Verify: ${reviewUrl}`;
+
+  const tasks: Promise<unknown>[] = [];
+
+  if (emailTo) {
+    const recipients = emailTo
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (recipients.length) {
+      tasks.push(
+        sendResendEmail({
+          to: recipients.length === 1 ? recipients[0]! : recipients,
+          subject: `[DocCy] New registration — ${payload.fullName}`,
+          text: textBody,
+        })
+      );
+    }
+  }
+
+  if (waWebhook) {
+    tasks.push(sendFounderWhatsApp(waWebhook, shortWa));
+  }
+
+  const results = await Promise.allSettled(tasks);
+  for (const r of results) {
+    if (r.status === "rejected") {
+      console.error("[DocCy] Founder registration notify channel failed", r.reason);
+    }
+  }
+}


### PR DESCRIPTION
- Introduced functionality to notify founders via email and WhatsApp when a new professional completes the signup process.
- Updated .env.example to include configuration options for founder notification emails and WhatsApp webhook URL.
- Integrated notification call in the registration handler to ensure founders are alerted upon successful registration.

## 🚀 Checklist de deployment
- [x] ⚠️ **IMPORTANTE**: ¿He copiado y ejecutado los nuevos scripts SQL en la base de datos de **PRODUCCIÓN** (DocCy)?
