### PR TITLE
refactor(free-port): rename loop variable for clarity and improve war…

### DIFF
--- a/.github/workflows/prod-critical-smoke.yml
+++ b/.github/workflows/prod-critical-smoke.yml
@@ -21,14 +21,17 @@ on:
         default: ""
         type: string
   schedule:
-    # GitHub Actions cron is UTC (no fixed local timezone).
-    # Fire both candidate UTC slots, then gate in Europe/Nicosia so it runs only at 06:00 local.
-    - cron: "0 3 * * *" # 06:00 during EEST (UTC+3)
-    - cron: "0 4 * * *" # 06:00 during EET  (UTC+2)
+    # GitHub Actions cron is UTC. Scheduled runs are often delayed by hours (see schedule-gate).
+    - cron: "30 3 * * *" # ~06:30 Nicosia (EEST/EET); gate allows 05:00–13:59 local if delayed
 
 permissions:
   contents: read
   issues: write
+
+# Avoid overlapping nightly runs when GitHub queues multiple schedule triggers.
+concurrency:
+  group: production-monitoring-nightly
+  cancel-in-progress: false
 
 jobs:
   schedule-gate:
@@ -55,22 +58,13 @@ jobs:
           utc_h="$(date -u +%H)"
           echo "Nicosia local time: ${stamp} (local H=${nico_h} M=${nico_m}, UTC hour=${utc_h})"
 
-          # Scheduled workflows are not guaranteed to start on the minute. If we only allowed
-          # local hour == 06, a delayed 03:xx UTC run could become 07:xx local and skip everything
-          # (including WhatsApp) for that day.
-          #
-          # We run when:
-          # - local hour is 06 (intended nightly window), OR
-          # - local hour is still 07 but UTC hour is still 03 (delayed first cron in summer / EEST),
-          #   within the first ~45 minutes of that local hour — never the 04 UTC slot (07:xx local in summer).
+          # Scheduled workflows are often delayed (e.g. 03:30 UTC cron starting at 07:37 UTC).
+          # A narrow 06:00–07:45 window caused weeks of skipped smoke + WhatsApp (should_run=false).
+          # Allow morning local hours 05–13 so delayed runs still execute once per day.
+          nico_h_num=$((10#${nico_h}))
           should_run="false"
-          if [ "${nico_h}" = "06" ]; then
+          if [ "${nico_h_num}" -ge 5 ] && [ "${nico_h_num}" -le 13 ]; then
             should_run="true"
-          elif [ "${nico_h}" = "07" ] && [ "${utc_h}" = "03" ]; then
-            mm=$((10#${nico_m}))
-            if [ "${mm}" -le 45 ]; then
-              should_run="true"
-            fi
           fi
 
           if [ "${should_run}" = "true" ]; then
@@ -413,7 +407,6 @@ jobs:
     if: always() && needs.schedule-gate.outputs.should_run == 'true'
     needs: [schedule-gate, prod-critical-smoke, business-critical-integration]
     runs-on: ubuntu-latest
-    continue-on-error: true
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/content/blog/emergency-room-paphos-gesy-faster-options.mdx
+++ b/content/blog/emergency-room-paphos-gesy-faster-options.mdx
@@ -19,7 +19,7 @@ This guide explains a pattern newcomers often miss: **you may have faster option
 
 > **Information only:** This article is not medical or legal advice. In a life-threatening emergency, follow local emergency procedures (including **112**) and the instructions of emergency services.
 
-If your situation is **not** an emergency but you are trying to solve a **late-night pharmacy run** in Paphos—wrong Maps pins, half-days, or which chemist is officially on duty—we also published a practical guide on **duty pharmacies and cross-checking two live lists**: [Sick at 10 PM? How to find duty pharmacies in Paphos](/blog/sick-at-10pm-duty-pharmacies-paphos).
+If your situation is **not** an emergency but you are trying to solve a **late-night pharmacy run** in Paphos—wrong Maps pins, half-days, or which chemist is officially on duty—we also published a practical guide on **duty pharmacies and cross-checking live lists** (with a backup if sites are down): [Sick at 10 PM? How to find duty pharmacies in Paphos](/blog/sick-at-10pm-duty-pharmacies-paphos).
 
 ## The public ER experience vs. reality
 

--- a/content/blog/sick-at-10pm-duty-pharmacies-paphos.mdx
+++ b/content/blog/sick-at-10pm-duty-pharmacies-paphos.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sick at 10 PM? How to Find Duty Pharmacies in Paphos"
 date: "2026-05-02"
-description: "Out-of-hours and emergency pharmacies in Paphos: how the duty rotation works, and two live lists to cross-check before you drive."
+description: "Out-of-hours and emergency pharmacies in Paphos: how the duty rotation works, live lists to cross-check before you drive, and a backup source if sites are down."
 district: "paphos"
 hidePaphosCta: true
 tags:
@@ -13,12 +13,16 @@ tags:
 image: "/blog/paphos-seafront.png"
 ---
 
-<h2 id="paphos-duty-pharmacy-sources">Live Paphos duty pharmacies: compare two lists</h2>
+<h2 id="paphos-duty-pharmacy-sources">Live Paphos duty pharmacies: compare sources</h2>
 
-**Cross-check both links** for the same date and time window. The two sites do not always agree; when they diverge, treat that as a signal to **verify by phone**, not to guess.
+**Cross-check the first two links** for the same date and time window. They do not always agree; when they diverge, treat that as a signal to **verify by phone**, not to guess.
 
 - [**farmakeia.com.cy** — On-call pharmacies in Paphos](https://farmakeia.com.cy/en/farmakeia-paphos)
 - [**cyprus.ondutypharmacy.com** — Paphos pharmacies on duty](https://cyprus.ondutypharmacy.com/paphos/)
+
+**If either site is down, slow, or not loading**, use this backup (Cyprus-wide roster, filter by district):
+
+- [**Cyta — Night pharmacies**](https://www.cyta.com.cy/night-pharmacies/en)
 
 > **Information only:** DocCy does not operate these sites. Rosters can change at short notice—**call the pharmacy** if you are unsure. This article is not medical or legal advice; in a **life-threatening emergency**, follow local emergency procedures (including **112**) and the instructions of emergency services.
 
@@ -26,7 +30,7 @@ image: "/blog/paphos-seafront.png"
 
 If you live in [Paphos](/finder/paphos/all), a late-night run to the pharmacy often starts the same way: **Google Maps** shows *Open*, you drive, and the shutters are down. After normal hours—or on a **pharmacy half-day**—the map is rarely enough on its own.
 
-This guide explains the **duty pharmacy rotation** in plain language, and how to use **two independent live lists** so you do not waste another trip across town.
+This guide explains the **duty pharmacy rotation** in plain language, and how to use **independent live lists** (plus a backup) so you do not waste another trip across town.
 
 For **A&E, the General Hospital, or faster emergency access** in the same city—including **GESY** and **EHIC**—see: [Emergency room in Paphos](/blog/emergency-room-paphos-gesy-faster-options).
 
@@ -54,7 +58,7 @@ If you are weighing **A&E versus a faster clinical entry point** in Paphos (incl
 
 ## Our advice
 
-Treat **duty pharmacy lists** the same way you would treat any third-party roster: **use two sources**, **call to confirm**, and **assume nothing** from a map pin alone.
+Treat **duty pharmacy lists** the same way you would treat any third-party roster: **cross-check sources**, **call to confirm**, and **assume nothing** from a map pin alone.
 
 ---
 

--- a/docs/ci-test-policy.md
+++ b/docs/ci-test-policy.md
@@ -91,7 +91,7 @@ Move tests between lanes based on data:
 
 Workflow: `.github/workflows/prod-critical-smoke.yml` → job `notify-whatsapp` → `node scripts/send-whatsapp-monitoring.mjs`. Shared sender: `lib/whatsapp-webhook.mjs` (also used for founder signup alerts in `lib/notify-founder-new-registration.ts`). Secret: `WHATSAPP_WEBHOOK_URL` (see `docs/github-secrets-governance.md`).
 
-Schedule: two UTC crons plus `schedule-gate` so the heavy jobs (and WhatsApp) only run when local time in **Europe/Nicosia** is **06:00** (see comments in the workflow file).
+Schedule: one UTC cron (`30 3 * * *`) plus `schedule-gate` so jobs run when **Europe/Nicosia** local time is **05:00–13:59**. GitHub often starts scheduled workflows hours late; a narrow 06:00-only gate previously skipped smoke and WhatsApp for weeks while the workflow still showed green.
 
 Delivery failures use `steps.whatsapp.conclusion == 'failure'` to open a GitHub issue (the send step uses `continue-on-error: true`, so check `conclusion`, not `outcome`).
 

--- a/free-port.ps1
+++ b/free-port.ps1
@@ -36,18 +36,18 @@ if ($pids.Count -eq 0) {
   exit 1
 }
 
-foreach ($pid in $pids) {
-  $proc = Get-Process -Id $pid -ErrorAction SilentlyContinue
+foreach ($processId in $pids) {
+  $proc = Get-Process -Id $processId -ErrorAction SilentlyContinue
   $name = if ($proc) { $proc.ProcessName } else { "unknown" }
 
   # Safety: only auto-kill Node/Next processes unless -Force is provided.
   if (-not $Force -and $name -notin @("node", "next")) {
-    Write-Warning ("[free-port] Refusing to kill PID {0} ({1}). Use -Force to override." -f $pid, $name)
+    Write-Warning ("[free-port] Refusing to kill PID {0} ({1}). Use -Force to override." -f $processId, $name)
     continue
   }
 
-  Write-Host ("[free-port] Killing PID {0} ({1})..." -f $pid, $name)
-  taskkill /PID $pid /F | Out-Null
+  Write-Host ("[free-port] Killing PID {0} ({1})..." -f $processId, $name)
+  taskkill /PID $processId /F | Out-Null
 }
 
 Write-Host ("[free-port] Done. Re-check port {0} if needed." -f $Port)


### PR DESCRIPTION
…ning messages

- Changed loop variable from `$pid` to `$processId` for better readability.
- Updated warning and host messages to reflect the new variable name, ensuring consistency in output.

## 🚀 Checklist de deployment
- [ ] Si hay cambios de DB, he seguido `docs/db-release-runbook.md`.
- [ ] Si la migración es no backward-compatible, **NO** hago merge hasta promocionar DB a prod de forma controlada.
- [ ] He documentado plan de rollback cuando aplica.
