### PR TITLE
chore: update test doctor email handling and documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 # Server-only: bypasses RLS — required for POST /api/appointments, success + .ics routes, and /internal/directory
 SUPABASE_SERVICE_ROLE_KEY=
 
+# Server-only: email substrings that mark a doctor as test (Finder hidden on prod). Default: rociosirvent
+# DOC_CY_TEST_DOCTOR_EMAIL_MARKERS=rociosirvent
+
 # Server-only (optional): anti-spam for finder "Vote for Online Booking".
 # Without this variable: votes still save; each click is a new row (easy to inflate).
 # With it: set a long random secret, restart dev / redeploy — then the same network cannot stack many votes on the same listing in 90 days.

--- a/docs/test-env-boundaries.md
+++ b/docs/test-env-boundaries.md
@@ -19,7 +19,9 @@ Using `.env.testing.local` with production URL can produce false failures (UI su
 | Founding Members counter | **Counts** verified founder test doctors (fewer spots shown) | Same — counts toward urgency display |
 | Founder tier at signup | Test rows do **not** consume one of the 100 real founder slots (RPC lock) | Same |
 
-Register prod smoke doctors with `@test-doccy.com.cy` (auto `is_test_profile`). Integration seed uses `@doccy.testing` / `andreas-nikos`.
+**Prod owner smoke:** any registration email containing `rociosirvent` (e.g. `rociosirvent+anastasiadoctor@gmail.com`) is auto `is_test_profile`. Override markers via server env `DOC_CY_TEST_DOCTOR_EMAIL_MARKERS` (comma-separated, lowercase substrings).
+
+CI smoke may still use `@test-doccy.com.cy` or `@doccy.testing`. Integration seed uses `andreas-nikos`.
 
 **Production persistent test doctor:** normal `/register` → verify in `/internal/directory` → set GitHub secrets `TEST_DOCTOR_EMAIL`, `TEST_DOCTOR_PASSWORD`, `TEST_BOOKING_DOCTOR_SLUG`. Booking uses `/{slug}`; Finder stays clean on prod.
 

--- a/lib/doctor-test-profile.ts
+++ b/lib/doctor-test-profile.ts
@@ -1,18 +1,35 @@
 /**
- * QA / smoke doctors: auto-flagged at registration by email domain.
+ * QA / smoke doctors: auto-flagged at registration by email patterns.
  *
  * - Prod: hidden from Finder; still counted in Founding Members availability (marketing urgency).
  * - Integration: set NEXT_PUBLIC_DOC_CY_FINDER_INCLUDE_TEST_PROFILES=1 so they appear in Finder too.
  * - Founder tier lock (RPC): test rows do not consume one of the 100 real founder slots at signup.
+ *
+ * Owner smoke aliases (e.g. rociosirvent+anastasiadoctor@gmail.com): DOC_CY_TEST_DOCTOR_EMAIL_MARKERS
+ * or default marker below. CI domains (@test-doccy.com.cy, @*.testing) stay supported.
  */
 const TEST_EMAIL_SUFFIXES = ["@test-doccy.com.cy", "@integration.test"] as const;
 
 /** Subdomains like `andreas-nikos.integration@doccy.testing`. */
 const TEST_EMAIL_DOMAIN_PATTERN = /@.+\.testing$/i;
 
+const DEFAULT_OWNER_TEST_EMAIL_MARKERS = ["rociosirvent"] as const;
+
+function getOwnerTestEmailMarkers(): string[] {
+  const fromEnv = String(process.env.DOC_CY_TEST_DOCTOR_EMAIL_MARKERS ?? "")
+    .split(",")
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+  return fromEnv.length > 0 ? fromEnv : [...DEFAULT_OWNER_TEST_EMAIL_MARKERS];
+}
+
 export function isTestDoctorRegistrationEmail(email: string | null | undefined): boolean {
   const normalized = String(email ?? "").trim().toLowerCase();
   if (!normalized.includes("@")) return false;
+
+  if (getOwnerTestEmailMarkers().some((marker) => normalized.includes(marker))) {
+    return true;
+  }
   if (TEST_EMAIL_SUFFIXES.some((suffix) => normalized.endsWith(suffix))) return true;
   return TEST_EMAIL_DOMAIN_PATTERN.test(normalized);
 }

--- a/supabase/migrations/20260529120000_owner_test_doctor_email_markers.sql
+++ b/supabase/migrations/20260529120000_owner_test_doctor_email_markers.sql
@@ -1,0 +1,19 @@
+-- Owner smoke aliases (rociosirvent+…@gmail.com) must be test profiles in prod.
+
+create or replace function public.is_test_doctor_registration_email(p_email text)
+returns boolean
+language sql
+immutable
+as $$
+  select coalesce(lower(trim(p_email)), '') ~ '@(test-doccy\.com\.cy|integration\.test)$'
+      or coalesce(lower(trim(p_email)), '') ~ '@.+\.testing$'
+      or coalesce(lower(trim(p_email)), '') like '%rociosirvent%';
+$$;
+
+comment on function public.is_test_doctor_registration_email(text) is
+  'QA/smoke emails: CI domains, @*.testing, and owner aliases containing rociosirvent.';
+
+update public.doctors
+set is_test_profile = true
+where coalesce(is_test_profile, false) = false
+  and public.is_test_doctor_registration_email(email);


### PR DESCRIPTION
- Added support for custom email markers to identify test doctors in production via the DOC_CY_TEST_DOCTOR_EMAIL_MARKERS environment variable.
- Updated the .env.example file to include the new configuration for test doctor email markers.
- Enhanced documentation on test environment boundaries to clarify the behavior of test doctors in production and integration environments.
- Refactored the doctor test profile logic to utilize the new email markers for improved flexibility in test doctor identification.

## 🚀 Checklist de deployment
- [ ] Si hay cambios de DB, he seguido `docs/db-release-runbook.md`.
- [ ] Si la migración es no backward-compatible, **NO** hago merge hasta promocionar DB a prod de forma controlada.
- [ ] He documentado plan de rollback cuando aplica.
